### PR TITLE
Use export path textbox for file saving

### DIFF
--- a/QueryExporter/UI_/MainWindow.xaml.cs
+++ b/QueryExporter/UI_/MainWindow.xaml.cs
@@ -90,47 +90,49 @@ namespace QueryExporter
                 MessageBox.Show("No data available to export.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
+
+            var filePath = ExportLocationTextBox.Text;
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                MessageBox.Show("Please specify an export location.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(filePath);
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                MessageBox.Show("The specified directory does not exist.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+
             // Set the LicenseContext to NonCommercial to comply with EPPlus licensing requirements
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
-            // Use SaveFileDialog to select file format and save location
-            using (var saveFileDialog = new WinForms.SaveFileDialog())
+
+            try
             {
-                saveFileDialog.Filter = "CSV Files (*.csv)|*.csv|Excel Files (*.xlsx)|*.xlsx|JSON Files (*.json)|*.json";
-                saveFileDialog.DefaultExt = "csv";
-                saveFileDialog.AddExtension = true;
+                var dataTable = ((DataView)ResultsDataGrid.ItemsSource).ToTable();
 
-                if (saveFileDialog.ShowDialog() == WinForms.DialogResult.OK)
+                switch (Path.GetExtension(filePath).ToLower())
                 {
-                    try
-                    {
-                        // Determine file extension from selected file type
-                        var filePath = saveFileDialog.FileName;
-                        var dataTable = ((DataView)ResultsDataGrid.ItemsSource).ToTable();
-
-                        // Call the appropriate export method based on file extension
-                        switch (Path.GetExtension(filePath).ToLower())
-                        {
-                            case ".csv":
-                                _fileHandler.ExportDataTableToCsv(dataTable, filePath);
-                                break;
-                            case ".xlsx":
-                                _fileHandler.ExportDataTableToExcel(dataTable, filePath);
-                                break;
-                            case ".json":
-                                _fileHandler.ExportDataTableToJson(dataTable, filePath);
-                                break;
-                            default:
-                                MessageBox.Show("Unsupported file format selected.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                                return;
-                        }
-
-                        MessageBox.Show("Data exported successfully!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show($"Export failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                    }
+                    case ".csv":
+                        _fileHandler.ExportDataTableToCsv(dataTable, filePath);
+                        break;
+                    case ".xlsx":
+                        _fileHandler.ExportDataTableToExcel(dataTable, filePath);
+                        break;
+                    case ".json":
+                        _fileHandler.ExportDataTableToJson(dataTable, filePath);
+                        break;
+                    default:
+                        MessageBox.Show("Unsupported file format selected.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
                 }
+
+                MessageBox.Show("Data exported successfully!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Export failed: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 


### PR DESCRIPTION
## Summary
- route exports through the ExportLocationTextBox path instead of SaveFileDialog
- validate destination directory and choose export routine by file extension

## Testing
- `dotnet build QueryExporter.sln` *(fails: command not found)*
- `apt-get update` *(403 errors, package repository unavailable)*
- `apt-get install -y dotnet-sdk-7.0` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68978bf88064832bbffbe79fc56fa625